### PR TITLE
Add GRUB_RECORDFAIL_TIMEOUT and add regexp lines to both GRUB*TIMEOUT options

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,10 +11,24 @@
 - name: set GRUB_TIMEOUT
   lineinfile:
     path: /etc/default/grub
+    regexp: '^GRUB_TIMEOUT'
     line: GRUB_TIMEOUT={{ grub_timeout }}
     create: yes
   notify:
     - update grub
+  when:
+    - grub_timeout is defined  
+
+- name: set GRUB_RECORDFAIL_TIMEOUT
+  lineinfile:
+    path: /etc/default/grub
+    regexp: '^GRUB_RECORDFAIL_TIMEOUT'
+    line: GRUB_RECORDFAIL_TIMEOUT={{ grub_timeout }}
+    create: yes
+  notify:
+    - update grub
+  when:
+    - grub_recordfail_timeout is defined
 
 - name: add options to GRUB_CMDLINE_LINUX
   replace:


### PR DESCRIPTION
While provisioning ubuntu VMs I found I needed to set GRUB_RECORDFAIL_TIMEOUT in order to set grub timeout. So I'd like to include the option grub_recordfail_timeout, which, when set, causes the option GRUB_RECORDFAIL_TIMEOUT to be included in /etc/default/grub.
I also included regexp lines to make sure to change both options "in place", rather than adding them to the file.