### PR TITLE
skip reboot on local connection

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,7 +6,7 @@
     cmd: "{{ grub_update_grub_command }}"
   changed_when: yes
   when:
-    - ansible_connection not in [ "container", "docker", "community.docker.docker" ]
+    - ansible_connection not in [ "container", "docker", "community.docker.docker", "local" ]
   notify:
     - Reboot
 


### PR DESCRIPTION
We have the use case to provision AWS AMIs with Ansible and struggle with the reboot attempt of grub. This fix helped us to mitigate the problem. As an alternative, we could also introduce another parameter that can be set.