### PR TITLE
create grub2-efi.cfg when missing

### DIFF
--- a/tasks/password.yml
+++ b/tasks/password.yml
@@ -28,6 +28,7 @@
     state: present
     insertafter: EOF
     line: 'password_pbkdf2 {{ grub_user }} {{ grub_password }}'
+    create: true
   when:
     - grub_efi.stat.exists
   notify:


### PR DESCRIPTION
---
name: create grub2-efi.cfg when missing
about: Fix issue #8

---

**Describe the change**
Pass "create: true" to the lineinfile module 
