### PR TITLE
Feat 12 set keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ grub_timeout: 5
 
 grub_recordfail_timeout: "{{ grub_timeout }}"
 
+grub_set_keymap: false
+grub_keyboard_layout: de
+
 grub_set_password: false
 grub_user: root
 # grub_password = changeme

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ grub_timeout: 5
 
 grub_recordfail_timeout: "{{ grub_timeout }}"
 
+grub_set_keymap: false
+grub_keyboard_layout: de
+
 grub_set_password: false
 grub_user: root
 # grub_password = changeme

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,8 @@ grub_timeout: 5
 grub_recordfail_timeout: "{{ grub_timeout }}"
 
 grub_set_keymap: false
-grub_keyboard_layout: de
+grub_keyboard_lang: de
+grub_keyboard_layout: azerty
 
 grub_set_password: false
 grub_user: root

--- a/tasks/keymap.yml
+++ b/tasks/keymap.yml
@@ -1,0 +1,32 @@
+---
+# tasks file for grub
+
+- name: keymap | Make keyboard layout file
+  ansible.builtin.command:
+    cmd: "grub-kbdcomp -o /boot/grub/{{ grub_keyboard_layout }}.gkb {{ grub_keyboard_layout }}"
+    creates: "/boot/grub/{{ grub_keyboard_layout }}.gkb"
+
+- name: keymap | Set grub terminal input
+  ansible.builtin.lineinfile:
+    dest: /etc/default/grub
+    regexp: "^GRUB_TERMINAL_INPUT="
+    state: present
+    insertafter: "GRUB_TERMINAL="
+    line: 'GRUB_TERMINAL_INPUT="at_keyboard"'
+  notify:
+    - Update grub
+
+- name: keymap | Load keymap
+  ansible.builtin.lineinfile:
+    dest: /etc/grub.d/40_custom
+    regexp: "{{ item.regexp }}"
+    state: present
+    insertafter: "EOF"
+    line: "{{ item.line }}"
+  loop:
+    - { regexp: 'insmod keylayouts', line: 'insmod keylayouts' }
+    - { regexp: 'keymap', line: 'keymap /boot/grub/{{ grub_keyboard_layout }}.gkb' }
+  notify:
+    - Update grub
+
+

--- a/tasks/keymap.yml
+++ b/tasks/keymap.yml
@@ -2,9 +2,9 @@
 # tasks file for grub
 
 - name: keymap | Make keyboard layout file
-  ansible.builtin.command:
-    cmd: "grub-kbdcomp -o /boot/grub/{{ grub_keyboard_layout }}.gkb {{ grub_keyboard_layout }}"
-    creates: "/boot/grub/{{ grub_keyboard_layout }}.gkb"
+  ansible.builtin.shell:
+    cmd: "{{ grub_make_keyboard_layout_command }}"
+    creates: "{{ grub_boot_directory }}/{{ grub_keyboard_lang }}.gkb"
 
 - name: keymap | Set grub terminal input
   ansible.builtin.lineinfile:
@@ -25,8 +25,7 @@
     line: "{{ item.line }}"
   loop:
     - { regexp: 'insmod keylayouts', line: 'insmod keylayouts' }
-    - { regexp: 'keymap', line: 'keymap /boot/grub/{{ grub_keyboard_layout }}.gkb' }
+    - { regexp: 'keymap', line: 'keymap {{ grub_boot_directory }}/{{ grub_keyboard_lang }}.gkb' }
   notify:
     - Update grub
-
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,11 @@
     - grub_options is defined
     - grub_options | length > 0
 
+- name: Import keymap.yml
+  ansible.builtin.import_tasks: keymap.yml
+  when:
+    - grub_set_keymap
+
 - name: Import password.yml
   ansible.builtin.import_tasks: password.yml
   when:

--- a/tasks/password.yml
+++ b/tasks/password.yml
@@ -42,7 +42,7 @@
     insertafter: EOF
     line: 'password_pbkdf2 {{ grub_user }} {{ grub_password }}'
   when:
-    - grub_efi.stat.exists
+    - not grub_efi.stat.exists
   notify:
     - Update grub
 

--- a/tasks/password.yml
+++ b/tasks/password.yml
@@ -28,6 +28,7 @@
     state: present
     insertafter: EOF
     line: 'password_pbkdf2 {{ grub_user }} {{ grub_password }}'
+    create: true
   when:
     - grub_efi.stat.exists
   notify:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -21,7 +21,8 @@ _grub_update_grub_command:
   RedHat: grub2-mkconfig -o /boot/grub2/grub.cfg
 
 _grub_boot_directory:
-  default: "/boot/grub"
+  default: "/boot/grub2"
+  Alpine: "/boot/grub"
   Debian: "/boot/grub"
   RedHat: "/boot/grub2"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,6 +8,9 @@ _grub_packages:
     - grub
   Debian:
     - grub2
+  RedHat:
+    - grub2-common
+    - grub2-tools-extra
 
 grub_packages: "{{ _grub_packages[ansible_facts['os_family']] | default(_grub_packages['default']) }}"
 
@@ -16,4 +19,16 @@ _grub_update_grub_command:
   Alpine: grub-mkconfig -o /boot/grub/grub.cfg
   Debian: update-grub
 
+_grub_boot_directory:
+  default: "/boot/grub"
+  Debian: "/boot/grub"
+  RedHat: "/boot/grub2"
+
+_grub_make_keyboard_layout_command:
+  default: "grub-kbdcomp -o /boot/grub/{{ grub_keyboard_lang }}.gkb {{ grub_keyboard_lang }}"
+  Debian: "grub-kbdcomp -o /boot/grub/{{ grub_keyboard_lang }}.gkb {{ grub_keyboard_lang }}"
+  RedHat: "zcat /usr/lib/kbd/keymaps/xkb/{{ grub_keyboard_lang }}-{{ grub_keyboard_layout }}.map.gz | grub2-mklayout -o /boot/grub2/{{ grub_keyboard_lang }}.gkb"
+
 grub_update_grub_command: "{{ _grub_update_grub_command[ansible_facts['os_family']] | default(_grub_update_grub_command['default']) }}"
+grub_make_keyboard_layout_command: "{{ _grub_make_keyboard_layout_command[ansible_facts['os_family']] | default(_grub_make_keyboard_layout_command['default']) }}"
+grub_boot_directory: "{{ _grub_boot_directory[ansible_facts['os_family']] | default(_grub_boot_directory['default']) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,6 +18,7 @@ _grub_update_grub_command:
   default: grub2-mkconfig -o /boot/grub2/grub.cfg
   Alpine: grub-mkconfig -o /boot/grub/grub.cfg
   Debian: update-grub
+  RedHat: grub2-mkconfig -o /boot/grub2/grub.cfg
 
 _grub_boot_directory:
   default: "/boot/grub"
@@ -27,7 +28,7 @@ _grub_boot_directory:
 _grub_make_keyboard_layout_command:
   default: "grub-kbdcomp -o /boot/grub/{{ grub_keyboard_lang }}.gkb {{ grub_keyboard_lang }}"
   Debian: "grub-kbdcomp -o /boot/grub/{{ grub_keyboard_lang }}.gkb {{ grub_keyboard_lang }}"
-  RedHat: "zcat /usr/lib/kbd/keymaps/xkb/{{ grub_keyboard_lang }}-{{ grub_keyboard_layout }}.map.gz | grub2-mklayout -o /boot/grub2/{{ grub_keyboard_lang }}.gkb"
+  RedHat: "grub2-kbdcomp -o /boot/grub/{{ grub_keyboard_lang }}.gkb {{ grub_keyboard_lang }}"
 
 grub_update_grub_command: "{{ _grub_update_grub_command[ansible_facts['os_family']] | default(_grub_update_grub_command['default']) }}"
 grub_make_keyboard_layout_command: "{{ _grub_make_keyboard_layout_command[ansible_facts['os_family']] | default(_grub_make_keyboard_layout_command['default']) }}"


### PR DESCRIPTION
---
name: Set keymap
about: Allow people to configure grub to match their keyboard layout.

---

**Describe the change**
Import a task file to configure the keyboard layout, when `grub_set_keymap` is set to `true`.

**Testing**

Run the role once in diff mode with the following settings:
```
grub_set_keymap: true
grub_keyboard_layout: fr
```

Check that only the expected changes are made. Check that grub on the target host is now in azerty.

Run the role again, notice no more change is triggered.

The feature works on both Debian 13 and RedHat 10. However, other parts of the role still triggers changes on RedHat 10.
