### PR TITLE
Leave grub*.cfg alone

### DIFF
--- a/tasks/password.yml
+++ b/tasks/password.yml
@@ -1,9 +1,4 @@
 ---
-- name: password | Get efi path
-  ansible.builtin.stat:
-    path: /sys/firmware/efi/efivars/
-  register: grub_efi
-
 - name: password | Install user template
   ansible.builtin.template:
     src: 01_users.j2
@@ -11,30 +6,6 @@
     owner: root
     group: root
     mode: '0700'
-  notify:
-    - Update grub
-
-- name: password | EFI | add password
-  ansible.builtin.lineinfile:
-    dest: /etc/grub2-efi.cfg
-    regexp: "^password_pbkdf2 {{ grub_user }} "
-    state: present
-    insertafter: EOF
-    line: 'password_pbkdf2 {{ grub_user }} {{ grub_password }}'
-  when:
-    - grub_efi.stat.exists
-  notify:
-    - Update grub
-
-- name: password | MBR | add password
-  ansible.builtin.lineinfile:
-    dest: /etc/grub2.cfg
-    regexp: "^password_pbkdf2 {{ grub_user }} "
-    state: present
-    insertafter: EOF
-    line: 'password_pbkdf2 {{ grub_user }} {{ grub_password }}'
-  when:
-    - grub_efi.stat.exists
   notify:
     - Update grub
 

--- a/tasks/password.yml
+++ b/tasks/password.yml
@@ -4,13 +4,6 @@
     path: /sys/firmware/efi/efivars/
   register: grub_efi
 
-- name: password | Remove unwanted grub.cfg on EFI systems
-  ansible.builtin.file:
-    state: absent
-    path: /boot/grub2/grub.cfg
-  when:
-    - grub_efi.stat.exists
-
 - name: password | Install user template
   ansible.builtin.template:
     src: 01_users.j2


### PR DESCRIPTION
---
name: Leave grub cfg alone
about: Rely solely on grub-mkconfig to fix issues #8 and #9

---

**Describe the change**
Some tasks prevent the role to work, as they are trying to manage grub2.cfg and grub2-efi.cfg files. This PR removes those tasks, as the appropriate way to manage these files is to use grub-mkconfig (which is already handled by the role).

**Testing**
Tested on Debian 13 and RHEL 10.